### PR TITLE
Fix memory leak due in DrupalSetup trait

### DIFF
--- a/src/DrupalSetup.php
+++ b/src/DrupalSetup.php
@@ -65,6 +65,9 @@ trait DrupalSetup
     foreach ($this->cleanupEntities as $entity) {
         $entity->delete();
     }
+    // Remove references to deleted entities and shut down Kernel so we don't leak memory.
+    $this->cleanupEntities = [];
+    $this->kernel->shutdown();
   }
 
   /**


### PR DESCRIPTION
I've got about 15 test classes running on `ExistingSiteTestCase`, and we're starting to see memory limit issues running the tests.  I did some profiling and discovered that we've got a memory leak due to the entities that have been marked for cleanup, and the Kernel not being shut down properly.  In other words, the entities and full Drupal container are being retained as properties of the test class even after tearDown has been invoked.  This PR resets the `cleanupEntities` array and shuts down the Kernel.